### PR TITLE
INSDC Project compliance: enforce field constraints and add Collaborator affiliation support

### DIFF
--- a/src/main/java/uk/ac/ebi/ena/webin/xml/conversion/model/ena/project/Collaborator.java
+++ b/src/main/java/uk/ac/ebi/ena/webin/xml/conversion/model/ena/project/Collaborator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 EMBL - European Bioinformatics Institute
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package uk.ac.ebi.ena.webin.xml.conversion.model.ena.project;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.Data;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"name", "affiliation"})
+@Data
+public class Collaborator {
+  @JacksonXmlProperty(localName = "NAME")
+  private String name;
+
+  @JacksonXmlProperty(localName = "AFFILIATION")
+  private String affiliation;
+}

--- a/src/main/java/uk/ac/ebi/ena/webin/xml/conversion/model/ena/project/Project.java
+++ b/src/main/java/uk/ac/ebi/ena/webin/xml/conversion/model/ena/project/Project.java
@@ -30,6 +30,7 @@ import uk.ac.ebi.ena.webin.xml.conversion.model.ena.mapping.ToXmlMapper;
   "name",
   "title",
   "description",
+  "collaborators",
   "sequencingProject",
   "adminProject",
   "relatedProjects",
@@ -47,6 +48,7 @@ public class Project implements ToXmlMapper<XmlProject> {
   private String name;
   private String title;
   private String description;
+  private List<Collaborator> collaborators;
   private SequencingProject sequencingProject;
   private AdminProject adminProject;
 
@@ -68,6 +70,7 @@ public class Project implements ToXmlMapper<XmlProject> {
     to.setName(name);
     to.setTitle(title);
     to.setDescription(description);
+    to.setCollaborators(collaborators);
 
     if (sequencingProject != null && sequencingProject.getLocusTagPrefixes() == null) {
       sequencingProject.setLocusTagPrefixes(Collections.emptyList());

--- a/src/main/java/uk/ac/ebi/ena/webin/xml/conversion/model/ena/project/XmlProject.java
+++ b/src/main/java/uk/ac/ebi/ena/webin/xml/conversion/model/ena/project/XmlProject.java
@@ -33,6 +33,7 @@ import uk.ac.ebi.ena.webin.xml.conversion.model.ena.mapping.FromXmlMapper;
   "name",
   "title",
   "description",
+  "collaborators",
   "sequencingProject",
   "adminProject",
   "relatedProjects",
@@ -66,6 +67,10 @@ public class XmlProject implements FromXmlMapper<Project> {
   @JacksonXmlProperty(localName = "DESCRIPTION")
   private String description;
 
+  @JacksonXmlElementWrapper(localName = "COLLABORATORS")
+  @JacksonXmlProperty(localName = "COLLABORATOR")
+  private List<Collaborator> collaborators;
+
   @JacksonXmlProperty(localName = "SUBMISSION_PROJECT")
   private SequencingProject sequencingProject;
 
@@ -96,6 +101,7 @@ public class XmlProject implements FromXmlMapper<Project> {
     to.setName(name);
     to.setTitle(title);
     to.setDescription(description);
+    to.setCollaborators(collaborators);
     to.setSequencingProject(sequencingProject);
     to.setAdminProject(adminProject);
     to.setRelatedProjects(relatedProjects);

--- a/src/main/resources/uk/ac/ebi/ena/sra/schema/ENA.project.xsd
+++ b/src/main/resources/uk/ac/ebi/ena/sra/schema/ENA.project.xsd
@@ -47,23 +47,49 @@
                             <xs:documentation> A short name of the project. </xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:element minOccurs="1" name="TITLE" type="xs:string">
+                    <xs:element minOccurs="1" name="TITLE">
                         <xs:annotation>
                             <xs:documentation> A short descriptive title for the project.
                     </xs:documentation>
                         </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:minLength value="20"/>
+                                <xs:maxLength value="250"/>
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:element>
-                    <xs:element minOccurs="0" name="DESCRIPTION" type="xs:string">
+                    <xs:element minOccurs="1" name="DESCRIPTION">
                         <xs:annotation>
                             <xs:documentation> A long description of the scope of the project.
                     </xs:documentation>
                         </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:minLength value="20"/>
+                                <xs:maxLength value="4000"/>
+                            </xs:restriction>
+                        </xs:simpleType>
                     </xs:element>
                     <xs:element minOccurs="0" name="COLLABORATORS">
                         <xs:complexType>
                             <xs:sequence>
-                                <xs:element maxOccurs="unbounded" name="COLLABORATOR"
-                                    type="xs:string"/>
+                                <xs:element maxOccurs="unbounded" name="COLLABORATOR">
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:element name="NAME" type="xs:string">
+                                                <xs:annotation>
+                                                    <xs:documentation> The name of the contributor. </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:element>
+                                            <xs:element minOccurs="0" name="AFFILIATION" type="xs:string">
+                                                <xs:annotation>
+                                                    <xs:documentation> The affiliation of the contributor. </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:element>
+                                        </xs:sequence>
+                                    </xs:complexType>
+                                </xs:element>
                             </xs:sequence>
                         </xs:complexType>
                     </xs:element>


### PR DESCRIPTION
## Summary

Align the Project entity in webin-xml with the [INSDC minimum specifications](https://github.com/INSDC-Repo/INSDC/tree/main/INSDC%20Minimal%20Specifications/Project).

## Changes

| # | INSDC Field | Requirement | Previous Status | Changes Made |
|---|-------------|-------------|-----------------|--------------|
| 1 | **Description** | Mandatory, 20-4000 chars | Optional (`minOccurs="0"`), no length check | XSD: changed to `minOccurs="1"`, added `minLength=20` / `maxLength=4000` restriction |
| 2 | **Title** | Mandatory, 20-250 chars | Mandatory, no length check | XSD: added `minLength=20` / `maxLength=250` restriction |
| 3 | **Submitter Name** | Mandatory | Present via `center_name` attribute | No change needed — already handled by `ObjectType` |
| 4 | **Project Type** | Umbrella or Submission | Present via `xs:choice` | No change needed — already enforced |
| 5 | **Contributor Name** | Optional | `COLLABORATOR` was a plain string | XSD: `COLLABORATOR` is now a complex type with `NAME` + `AFFILIATION` children. New `Collaborator.java` model. `collaborators` field added to `Project.java` and `XmlProject.java` with mapping in both directions. |
| 6 | **Contributor Affiliation** | Optional | Missing entirely | Covered by the same `COLLABORATOR` restructure above — `AFFILIATION` is an optional child element |
| 7 | **Publication** | Optional (PubMed/DOI) | Present via `PROJECT_LINKS` | No change needed — already supported via XREF links |

## Files changed

- `ENA.project.xsd` — Description mandatory + length constraints on Title/Description + Collaborator restructure
- `Project.java` — Added `collaborators` field + mapping
- `XmlProject.java` — Added `collaborators` field with XML annotations + mapping
- `Collaborator.java` — New model class (name + affiliation)

## Not addressed at schema level

These are application-level concerns that cannot be enforced via XSD:

- **ASCII-only** constraint — requires application-layer validation
- **Uniqueness per submitter** — database/application constraint
- **Hierarchy rules** (umbrellas can't have data directly, submission projects can't be parents) — business logic enforcement

## Testing
**Important**: No tests have been run (no access to GitLab token)
